### PR TITLE
Add beginner quickstart docs and screenshot capture checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Quick links:
 - [Deploy a Live Demo](#deploy-a-live-demo)
 - [Troubleshooting](#troubleshooting)
 - [Learning Path](#learning-path)
+- [First 10 Minutes (Beginner Click Guide)](#first-10-minutes-beginner-click-guide)
 - [Sharing for Learning](#sharing-for-learning)
 - [Public Launch Checklist](#public-launch-checklist)
 - [Analytics and Privacy](#analytics-and-privacy)
@@ -181,6 +182,18 @@ Use this repo as a hands-on GitHub + Flask lab.
 3. Review code, tests, config, docs, and security impact
 4. Check CI and release/package workflows
 
+## First 10 Minutes (Beginner Click Guide)
+If you are brand new to GitHub, start with:
+- `docs/FIRST_10_MINUTES.md`
+
+This is a click-by-click walkthrough that shows exactly where to go first:
+- repo homepage / README
+- pinned `Start Here` issue
+- workshop issues
+- Actions
+- Releases
+- Packages
+
 ## Sharing for Learning
 To share this repo with learners effectively:
 
@@ -219,6 +232,7 @@ Short version:
 ## Learn GitHub Using This Repo
 Start here:
 - `README.md` (project overview)
+- `docs/FIRST_10_MINUTES.md` (fast beginner click guide)
 - `CONTRIBUTING.md` (branching, commit, PR flow)
 - `docs/GITHUB_GUIDE.md` (GitHub UI walkthrough)
 - `docs/PR_REVIEW_CHECKLIST.md` (how to review PRs)
@@ -247,6 +261,7 @@ This repository is configured as a practical GitHub example and includes:
 ## Visual Walkthrough Assets
 Screenshot/GIF placeholders and capture plan live in:
 - `docs/images/README.md`
+- `docs/images/CAPTURE_CHECKLIST.md`
 
 Add screenshots there to make the GitHub guide more visual for friends and learners.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,48 @@
+# Roadmap
+
+This roadmap keeps the project useful as both a Flask scaffold and a GitHub learning repo.
+
+## Now (Current Focus)
+
+- Keep beginner docs clear and accurate
+- Maintain CI / Release / GHCR package workflows
+- Improve visual learning materials (screenshots/GIFs)
+- Keep workshop issues beginner-friendly
+- Review and merge dependency/security updates safely
+
+## Next (High Impact)
+
+- Add real screenshots to `docs/images/`
+- Add a live demo deployment and set `About -> Website`
+- Add a short walkthrough video link in `README.md`
+- Enable GitHub Discussions for beginner questions
+- Add more workshop issues (docs, tests, workflow-reading)
+
+## Later (Professional Polish)
+
+- Add `docs/FAQ.md` for repeated beginner questions
+- Add a GitHub Pages docs site for `docs/`
+- Add a "broken branch" practice exercise for debugging + PR review
+- Add a deployment workflow for a demo environment
+- Add a lightweight architecture diagram image export
+
+## Maintenance Routine (Owner)
+
+Weekly:
+- Check `Insights -> Traffic`
+- Check `Issues` / `Pull requests`
+- Check `Actions`
+- Review Dependabot PRs/alerts
+
+Monthly:
+- Review collaborator access
+- Refresh beginner docs if learners get stuck on the same step
+- Add or rotate a workshop exercise
+
+## Release Discipline
+
+- `PATCH` for docs/bug fixes (`v0.2.4`)
+- `MINOR` for new features/learning content (`v0.3.0`)
+- `MAJOR` for breaking changes (`v1.0.0`)
+
+See `docs/VERSIONING_AND_RELEASES.md` for the full release flow.

--- a/docs/FIRST_10_MINUTES.md
+++ b/docs/FIRST_10_MINUTES.md
@@ -1,0 +1,63 @@
+# First 10 Minutes
+
+Use this if you are brand new to GitHub or coding projects.
+
+## Goal
+
+In 10 minutes, you will:
+- understand what this repo is
+- find the beginner docs
+- see where practice tasks live
+- see where updates/checks happen
+
+## What You Need
+
+- A web browser
+- A GitHub account (optional if you are only looking)
+
+## Step-by-Step (Clicks)
+
+1. Open the repository homepage.
+2. Look at the top tabs:
+   - `Code`
+   - `Issues`
+   - `Pull requests`
+   - `Actions`
+   - `Releases`
+3. Scroll the main page and read the top of `README.md`.
+4. In the README, open:
+   - `docs/GITHUB_GUIDE.md`
+   - `docs/SAFE_SHARING.md` (if you want to share or post it)
+5. Click the `Issues` tab.
+6. Open the pinned issue:
+   - `#9 Start Here: Learn GitHub + Flask using this repo`
+7. Pick one workshop issue:
+   - `#4` tiny README improvement
+   - `#5` inspect workflows
+   - `#6` practice PR review
+   - `#7` deploy a demo
+8. Click the `Actions` tab and open a green run.
+9. Click the `Releases` section and open the latest release.
+10. Optional: click `Packages` to see the GHCR container package workflow result.
+
+## If You Want to Practice Safely
+
+1. Click `Fork` (top-right).
+2. Make a tiny change in your own copy.
+3. Open a Pull Request in your fork.
+4. Watch `Actions` run checks.
+
+You cannot break the original project by doing this in your own fork.
+
+## What Each Tab Means (Quick)
+
+- `Code` = files and README
+- `Issues` = tasks/questions
+- `Pull requests` = proposed changes
+- `Actions` = automated checks
+- `Releases` = published versions
+
+## Next Step After 10 Minutes
+
+- Read `docs/GITHUB_GUIDE.md` for a deeper walkthrough
+- Try issue `#4` for your first hands-on task

--- a/docs/images/CAPTURE_CHECKLIST.md
+++ b/docs/images/CAPTURE_CHECKLIST.md
@@ -1,0 +1,74 @@
+# Screenshot Capture Checklist
+
+Use this checklist when preparing screenshots/GIFs for beginners.
+
+## Goal
+
+Capture a clean visual walkthrough that is easy for non-technical users to follow.
+
+## Before You Capture (Safety)
+
+1. Confirm the repo is the correct one: `dkupratis-debug/FlaskAppEnhanced`
+2. Close unrelated tabs/windows
+3. Hide bookmarks bar if it shows private links
+4. Make sure no secrets/tokens are visible anywhere
+5. Sign out of any account you do not want shown
+6. Crop or blur profile menus/notifications if needed
+
+## Browser Setup (Consistency)
+
+1. Set browser zoom to `100%`
+2. Use one browser for all screenshots
+3. Use a desktop-sized window (not tiny)
+4. Keep the same window size for all captures
+
+## Exact Screenshots to Capture (Recommended Order)
+
+1. Repo homepage (`Code` tab)
+   - Include repo name, visibility badge, top tabs, and README start
+   - Save as `github-code-tab.png`
+2. Pinned `Start Here` issue
+   - Show issue title and first section
+   - Save as `github-start-here-issue.png`
+3. Workshop issues list
+   - Show labels and pinned issue
+   - Save as `github-issues-list.png`
+4. Pull Request conversation page
+   - Show checks summary and review area (use a sample PR)
+   - Save as `github-pr-conversation.png`
+5. Pull Request `Files changed` tab
+   - Show line comments area if possible
+   - Save as `github-pr-files-changed.png`
+6. Actions run (successful)
+   - Show workflow name and green checks
+   - Save as `github-actions-run-success.png`
+7. Releases page
+   - Show latest release and assets
+   - Save as `github-release-page.png`
+8. Packages page (if visible/public)
+   - Show package name and tags
+   - Save as `github-package-page.png`
+9. Branch protection / ruleset screen (optional advanced)
+   - Save as `github-branch-protection.png`
+
+## Optional GIFs (5-15 seconds)
+
+1. Open a PR and watch checks start
+   - `open-pr-and-watch-ci.gif`
+2. Find a workflow run in `Actions`
+   - `find-workflow-run-in-actions.gif`
+3. Open a release and inspect assets
+   - `create-release-and-view-assets.gif`
+
+## Quality Checklist (Before Saving)
+
+- Text is readable without zooming too much
+- Important UI labels are visible
+- No private or personal info is visible
+- Filenames match the plan in `docs/images/README.md`
+
+## After Capture
+
+1. Save files into `docs/images/`
+2. Update `README.md` and/or `docs/GITHUB_GUIDE.md` to embed the screenshots
+3. Keep image sizes reasonable (prefer PNG, compress if needed)

--- a/docs/images/README.md
+++ b/docs/images/README.md
@@ -25,6 +25,10 @@ Use this folder for screenshots and short GIFs that make the GitHub learning wal
 - Prefer PNG for screenshots, GIF or MP4 for short demos
 - Keep images under ~1-2 MB when possible
 
+## Exact Capture Checklist
+- Use `docs/images/CAPTURE_CHECKLIST.md` for a step-by-step click/capture plan
+- Use the recommended filenames there so README/docs links stay consistent
+
 ## Safe Sharing Tip
 Before capturing GitHub screens for public sharing:
 - confirm no secrets/tokens are visible


### PR DESCRIPTION
## Summary
- add a 10-minute beginner click guide for first-time GitHub users
- add a repo roadmap with now/next/later priorities and maintenance routine
- add an exact screenshot/GIF capture checklist for sharing and docs
- link the new docs from README and docs/images/README

## Testing
- [x] ruff check .
- [x] git diff --check

## Why
These docs make the repo easier to use for non-technical learners and make visual walkthrough content easier to produce consistently.