### PR TITLE
Add training operations playbook and learner help template

### DIFF
--- a/.github/ISSUE_TEMPLATE/learner_help.yml
+++ b/.github/ISSUE_TEMPLATE/learner_help.yml
@@ -1,0 +1,53 @@
+name: Learner help request
+description: Ask for help while working through training tasks
+title: "[Help]: "
+labels: ["learning"]
+body:
+  - type: input
+    id: track
+    attributes:
+      label: Learning track
+      description: Which track are you on?
+      placeholder: "Track A (Beginner)"
+    validations:
+      required: true
+  - type: input
+    id: step
+    attributes:
+      label: Current step
+      description: Which step/exercise are you stuck on?
+      placeholder: "Practice Example 3, step 2"
+    validations:
+      required: true
+  - type: textarea
+    id: summary
+    attributes:
+      label: What happened?
+      description: Short summary of the problem
+      placeholder: "I expected..., but I saw..."
+    validations:
+      required: true
+  - type: textarea
+    id: commands
+    attributes:
+      label: Commands you ran
+      description: Paste exact commands and outputs if relevant
+      render: shell
+    validations:
+      required: false
+  - type: textarea
+    id: error
+    attributes:
+      label: Error message
+      description: Paste the full error text
+      render: shell
+    validations:
+      required: false
+  - type: textarea
+    id: env
+    attributes:
+      label: Environment
+      description: OS, Python version, and anything else relevant
+      placeholder: "Windows 11, Python 3.13"
+    validations:
+      required: true

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Quick links:
 - [First 10 Minutes (Beginner Click Guide)](#first-10-minutes-beginner-click-guide)
 - [Practice Examples](#practice-examples)
 - [FAQ](#faq)
+- [Training Operations](#training-operations)
 - [Sharing for Learning](#sharing-for-learning)
 - [Public Launch Checklist](#public-launch-checklist)
 - [Analytics and Privacy](#analytics-and-privacy)
@@ -223,6 +224,11 @@ This file gives exact tasks, success checks, and a recommended order.
 For common learner questions, use:
 - `docs/FAQ.md`
 
+## Training Operations
+For maintainers running this repo as a training program, use:
+- `docs/TRAINING_OPERATIONS.md`
+- `docs/LEARNER_PROGRESS_TEMPLATE.md`
+
 ## Sharing for Learning
 To share this repo with learners effectively:
 
@@ -267,6 +273,8 @@ Start here:
 - `docs/PRACTICE_EXAMPLES.md` (guided exercises with success checks)
 - `docs/LEARNING_TRACKS.md` (structured training paths)
 - `docs/FAQ.md` (common questions and fixes)
+- `docs/TRAINING_OPERATIONS.md` (weekly/monthly training routine)
+- `docs/LEARNER_PROGRESS_TEMPLATE.md` (progress tracking template)
 - `docs/COACHING_REPLY_TEMPLATES.md` (support reply templates)
 - `CONTRIBUTING.md` (branching, commit, PR flow)
 - `docs/GITHUB_GUIDE.md` (GitHub UI walkthrough)

--- a/docs/LEARNER_PROGRESS_TEMPLATE.md
+++ b/docs/LEARNER_PROGRESS_TEMPLATE.md
@@ -1,0 +1,26 @@
+# Learner Progress Template
+
+Use this table to track learner progress over time.
+
+## Per-Learner Tracking
+
+| Learner | Track | Current Exercise | Last Activity | Blocker | Next Action |
+|---|---|---|---|---|---|
+| Example User | Track A | Exercise 2 | 2026-02-27 | None | Start Exercise 3 |
+
+## Cohort Snapshot
+
+| Metric | Value |
+|---|---|
+| Active learners | 0 |
+| New learners this week | 0 |
+| PRs opened this week | 0 |
+| PRs merged this week | 0 |
+| Help issues opened | 0 |
+| Avg first response time | N/A |
+
+## Notes
+
+- Update this weekly.
+- Use this with `docs/TRAINING_OPERATIONS.md`.
+- Keep personal info minimal; prefer usernames only.

--- a/docs/TRAINING_OPERATIONS.md
+++ b/docs/TRAINING_OPERATIONS.md
@@ -1,0 +1,60 @@
+# Training Operations Playbook
+
+Use this as the maintainer routine for running the repo as a training program.
+
+## Weekly Cadence
+
+1. Review engagement:
+   - `Insights -> Traffic`
+   - new issues and PRs
+2. Publish one weekly challenge issue.
+3. Respond to learner help issues using `docs/COACHING_REPLY_TEMPLATES.md`.
+4. Merge safe docs/training improvements.
+5. Post one community update (for example, Facebook progress note).
+
+## Monthly Cadence
+
+1. Review collaborator access.
+2. Review open security alerts.
+3. Refresh `docs/FAQ.md` based on repeated learner blockers.
+4. Add one new practice example.
+
+## Suggested Training KPIs
+
+- New learners this week
+- Issues opened by learners
+- PRs opened by learners
+- PRs merged by learners
+- Average time to first maintainer response
+- Common failure categories (tests, lint, workflow, git basics)
+
+## Support Priority Triage
+
+1. Security concern
+2. Learner blocked on setup
+3. CI/check failure
+4. General question or coaching
+
+## Fast Response Workflow
+
+1. Acknowledge issue.
+2. Request missing details (commands/errors/environment).
+3. Point to exact docs path.
+4. Give one concrete next action.
+5. Confirm resolution and suggest the next exercise.
+
+## Recommended Weekly Challenge Rotation
+
+Week 1:
+- beginner README PR task
+
+Week 2:
+- Actions and checks investigation
+
+Week 3:
+- PR review exercise
+
+Week 4:
+- release/package or deployment walkthrough
+
+Repeat with new variants and gradually increase difficulty.


### PR DESCRIPTION
## Summary
- add docs/TRAINING_OPERATIONS.md for weekly/monthly training operations
- add docs/LEARNER_PROGRESS_TEMPLATE.md for progress tracking
- add .github/ISSUE_TEMPLATE/learner_help.yml for structured learner support requests
- update README links for new training assets

## Validation
- [x] ruff check .
- [x] pytest -q tests
- [x] git diff --check