### PR TITLE
Improve discussions engagement links and response expectations

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
+  - name: Ask in Discussions (Q&A)
+    url: https://github.com/dkupratis-debug/FlaskAppEnhanced/discussions/categories/q-a
+    about: Ask beginner questions, troubleshooting questions, and workflow questions here.
   - name: Security vulnerability report
     url: https://github.com/dkupratis-debug/FlaskAppEnhanced/security/policy
     about: Please report security vulnerabilities using the repository security policy.

--- a/.github/ISSUE_TEMPLATE/learner_help.yml
+++ b/.github/ISSUE_TEMPLATE/learner_help.yml
@@ -3,6 +3,11 @@ description: Ask for help while working through training tasks
 title: "[Help]: "
 labels: ["learning"]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        For fast support, you can also ask in Discussions Q&A:
+        https://github.com/dkupratis-debug/FlaskAppEnhanced/discussions/categories/q-a
   - type: input
     id: track
     attributes:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,3 +12,10 @@ Paste logs, screenshots, or API responses here.
 ## Risks / Notes
 - Any behavior changes?
 - Any follow-up work?
+
+## Learner Support
+- If this PR changes learner workflow/docs, did you update:
+  - `docs/FIRST_10_MINUTES.md` (if needed)
+  - `docs/DISCUSSIONS_GUIDE.md` (if needed)
+- For questions from learners, point them to:
+  - Start Here discussion: `https://github.com/dkupratis-debug/FlaskAppEnhanced/discussions/29`

--- a/docs/DISCUSSIONS_GUIDE.md
+++ b/docs/DISCUSSIONS_GUIDE.md
@@ -24,6 +24,13 @@ Use GitHub Discussions for learner questions, ideas, and progress updates.
 1. Close the loop by linking resolved PRs back into the discussion thread.
 1. Remove secrets, tokens, or sensitive information immediately if posted.
 
+## Response Time Expectations
+
+- `Q&A`: initial maintainer response target is within 24 hours.
+- `Learner help` style questions: target is same day when possible.
+- `Ideas` and `Show and tell`: acknowledge within 48 hours.
+- If an answer requires deeper investigation, post a status update in the thread so learners know it is being worked.
+
 ## Safety Rules for Public Learning
 
 - Never post `.env` values, API keys, or access tokens.


### PR DESCRIPTION
Adds Discussions cross-links in issue/PR templates and documents maintainer response-time expectations for learner support.