### PR TITLE
Add v3 launchpad + engagement automation workflows

### DIFF
--- a/.github/workflows/playground_branch_generator.yml
+++ b/.github/workflows/playground_branch_generator.yml
@@ -1,0 +1,83 @@
+name: Playground Branch Generator
+
+on:
+  workflow_dispatch:
+    inputs:
+      scenario:
+        description: "Failure scenario to generate"
+        required: true
+        type: choice
+        options:
+          - markdownlint
+          - test
+          - yamllint
+          - links
+      create_pr:
+        description: "Open a PR automatically after branch push"
+        required: true
+        type: boolean
+        default: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Create scenario branch
+        id: branch
+        run: |
+          SCENARIO="${{ inputs.scenario }}"
+          BRANCH="playground/${SCENARIO}-$(date +%Y%m%d-%H%M%S)"
+          git checkout -b "$BRANCH"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+
+      - name: Apply scenario change
+        run: |
+          SCENARIO="${{ inputs.scenario }}"
+          if [ "$SCENARIO" = "markdownlint" ]; then
+            printf "\n   - intentionally bad indent for markdownlint drill\n11. wrong numbering style\n" >> docs/BROKEN_TO_FIXED_SCENARIOS.md
+          elif [ "$SCENARIO" = "test" ]; then
+            perl -0777 -i -pe "s/assert b\"FlaskAppEnhanced\" in res\\.data/assert b\"FlaskAppEnhanced-BROKEN\" in res.data/" tests/test_app.py
+          elif [ "$SCENARIO" = "yamllint" ]; then
+            printf "broken:\n   wrong: indent\n  bad: true\n" > .github/playground-invalid.yml
+          elif [ "$SCENARIO" = "links" ]; then
+            printf "\n- Broken training link: https://example.invalid/definitely-broken\n" >> README.md
+          fi
+
+      - name: Commit and push branch
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .
+          git commit -m "Create playground failing scenario: ${{ inputs.scenario }}"
+          git push -u origin "${{ steps.branch.outputs.branch }}"
+
+      - name: Open pull request
+        if: ${{ inputs.create_pr }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const branch = `${{ steps.branch.outputs.branch }}`;
+            const scenario = `${{ inputs.scenario }}`;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            await github.rest.pulls.create({
+              owner,
+              repo,
+              head: branch,
+              base: "main",
+              title: `Playground scenario: failing ${scenario}`,
+              body: [
+                `This PR intentionally introduces a failing CI scenario for training.`,
+                ``,
+                `Scenario: \`${scenario}\``,
+                `Goal: practice diagnosis and fix workflow.`,
+                `Reference: docs/BROKEN_TO_FIXED_SCENARIOS.md`
+              ].join("\n")
+            });

--- a/.github/workflows/weekly_leaderboard.yml
+++ b/.github/workflows/weekly_leaderboard.yml
@@ -1,0 +1,95 @@
+name: Weekly Leaderboard
+
+on:
+  schedule:
+    - cron: "0 13 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  leaderboard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create weekly leaderboard issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const now = new Date();
+            const since = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+            const sinceIso = since.toISOString();
+            const title = `Weekly Community Leaderboard (${now.toISOString().slice(0, 10)})`;
+
+            const scores = new Map();
+            const bump = (login, field, weight) => {
+              if (!login) return;
+              const row = scores.get(login) || { prOpened: 0, prMerged: 0, issuesOpened: 0, discussionsStarted: 0, score: 0 };
+              row[field] += 1;
+              row.score += weight;
+              scores.set(login, row);
+            };
+
+            // Pull requests
+            const pulls = await github.paginate(github.rest.pulls.list, {
+              owner, repo, state: "all", per_page: 100, sort: "updated", direction: "desc"
+            });
+            for (const pr of pulls) {
+              if (new Date(pr.created_at) >= since) bump(pr.user?.login, "prOpened", 3);
+              if (pr.merged_at && new Date(pr.merged_at) >= since) bump(pr.user?.login, "prMerged", 5);
+            }
+
+            // Issues (exclude PRs)
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner, repo, state: "all", since: sinceIso, per_page: 100
+            });
+            for (const issue of issues) {
+              if (issue.pull_request) continue;
+              if (new Date(issue.created_at) >= since) bump(issue.user?.login, "issuesOpened", 1);
+            }
+
+            // Discussions (started)
+            const discussionQuery = `
+              query($owner:String!, $name:String!) {
+                repository(owner:$owner, name:$name) {
+                  discussions(first: 100, orderBy:{field:UPDATED_AT, direction:DESC}) {
+                    nodes {
+                      createdAt
+                      author { login }
+                    }
+                  }
+                }
+              }
+            `;
+            const d = await github.graphql(discussionQuery, { owner, name: repo });
+            for (const node of d.repository.discussions.nodes) {
+              if (new Date(node.createdAt) >= since) bump(node.author?.login, "discussionsStarted", 2);
+            }
+
+            const rows = [...scores.entries()]
+              .sort((a, b) => b[1].score - a[1].score)
+              .slice(0, 15);
+
+            let body = `# Weekly Community Leaderboard\n\n`;
+            body += `Window: ${since.toISOString().slice(0, 10)} to ${now.toISOString().slice(0, 10)}\n\n`;
+            body += `| Rank | User | Score | PR Opened | PR Merged | Issues Opened | Discussions Started |\n`;
+            body += `|---|---|---:|---:|---:|---:|---:|\n`;
+            if (rows.length === 0) {
+              body += `| - | _No qualifying activity this week_ | 0 | 0 | 0 | 0 | 0 |\n`;
+            } else {
+              rows.forEach(([login, r], idx) => {
+                body += `| ${idx + 1} | @${login} | ${r.score} | ${r.prOpened} | ${r.prMerged} | ${r.issuesOpened} | ${r.discussionsStarted} |\n`;
+              });
+            }
+            body += `\nScoring: PR opened=3, PR merged=5, issue opened=1, discussion started=2.\n`;
+
+            await github.rest.issues.create({
+              owner,
+              repo,
+              title,
+              body,
+              labels: ["learning"]
+            });

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This repository is also set up as a GitHub learning example: you can use it to u
 
 Quick links:
 - App docs and setup: `README.md`
+- Public launchpad page: `/launch`
 - Docs index: `docs/INDEX.md`
 - Role-based onboarding: `docs/START_HERE_BY_ROLE.md`
 - GitHub walkthrough: `docs/GITHUB_GUIDE.md`
@@ -22,6 +23,7 @@ Quick links:
 - Contributing workflow: `CONTRIBUTING.md`
 - Security reporting: `SECURITY.md`
 - Security best practices: `docs/SECURITY_BEST_PRACTICES.md`
+- Engagement automation: `docs/ENGAGEMENT_AUTOMATION.md`
 
 ## Table of Contents
 - [Features](#features)
@@ -39,6 +41,7 @@ Quick links:
 - [Start Here by Role](#start-here-by-role)
 - [Interactive Learning Dashboard](#interactive-learning-dashboard)
 - [Interactive Learning Lab](#interactive-learning-lab)
+- [Public Launchpad](#public-launchpad)
 - [CI Troubleshooting Flow](#ci-troubleshooting-flow)
 - [Broken to Fixed Scenarios](#broken-to-fixed-scenarios)
 - [First 10 Minutes (Beginner Click Guide)](#first-10-minutes-beginner-click-guide)
@@ -240,6 +243,16 @@ This page includes:
 - failing CI fix simulation
 - release/tag flow simulation
 - command and expected-output walk-throughs
+
+## Public Launchpad
+For a share-friendly entry page with guided calls to action, open:
+- `/launch`
+
+This page includes:
+- learner onboarding cards
+- community and discussion entry points
+- contribution links
+- quality/security links
 
 ## CI Troubleshooting Flow
 When any required GitHub check fails, use:

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -132,6 +132,10 @@ def create_app():
     def learn():
         return render_template("learn.html")
 
+    @app.get("/launch")
+    def launch():
+        return render_template("launch.html")
+
     @app.get("/learn-lab")
     def learn_lab():
         return render_template("learn_lab.html")

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -110,3 +110,9 @@ h2 {
 #copy-output {
   margin-bottom: 8px;
 }
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 16px;
+}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -6,6 +6,7 @@
   <div class="card">
     <p><strong>Status:</strong> <span class="badge">Running</span></p>
     <p>Health check: <code>/health</code></p>
+    <p>Launchpad: <a href="/launch"><code>/launch</code></a></p>
     <p>Learning dashboard: <a href="/learn"><code>/learn</code></a></p>
     <p>Interactive lab demo: <a href="/learn-lab"><code>/learn-lab</code></a></p>
   </div>

--- a/app/templates/launch.html
+++ b/app/templates/launch.html
@@ -1,0 +1,62 @@
+{% extends "layout.html" %}
+
+{% block content %}
+  <h1>FlaskAppEnhanced Launchpad</h1>
+  <p>Start learning fast, contribute safely, and track your progress in one place.</p>
+
+  <div class="card-grid">
+    <section class="card">
+      <h2>New Learners</h2>
+      <p>Start with role-based onboarding and click-by-click guides.</p>
+      <ul>
+        <li><a href="https://github.com/dkupratis-debug/FlaskAppEnhanced/blob/main/docs/START_HERE_BY_ROLE.md" target="_blank" rel="noreferrer">Start Here by Role</a></li>
+        <li><a href="https://github.com/dkupratis-debug/FlaskAppEnhanced/blob/main/docs/FIRST_10_MINUTES.md" target="_blank" rel="noreferrer">First 10 Minutes</a></li>
+      </ul>
+    </section>
+
+    <section class="card">
+      <h2>Interactive Demo</h2>
+      <p>Practice simulations before working on real PRs.</p>
+      <ul>
+        <li><a href="/learn">Learning Dashboard</a></li>
+        <li><a href="/learn-lab">Interactive Learning Lab</a></li>
+      </ul>
+    </section>
+
+    <section class="card">
+      <h2>Contribute</h2>
+      <p>Open a safe practice issue or submit a PR.</p>
+      <ul>
+        <li><a href="https://github.com/dkupratis-debug/FlaskAppEnhanced/issues/new/choose" target="_blank" rel="noreferrer">Open an Issue</a></li>
+        <li><a href="https://github.com/dkupratis-debug/FlaskAppEnhanced/pulls" target="_blank" rel="noreferrer">View Pull Requests</a></li>
+      </ul>
+    </section>
+
+    <section class="card">
+      <h2>Community</h2>
+      <p>Ask questions, share wins, and vote on next topics.</p>
+      <ul>
+        <li><a href="https://github.com/dkupratis-debug/FlaskAppEnhanced/discussions/29" target="_blank" rel="noreferrer">Start Here Discussion</a></li>
+        <li><a href="https://github.com/dkupratis-debug/FlaskAppEnhanced/discussions/categories/q-a" target="_blank" rel="noreferrer">Q&A Discussions</a></li>
+      </ul>
+    </section>
+
+    <section class="card">
+      <h2>Quality and Security</h2>
+      <p>See repo health and safety posture in plain English.</p>
+      <ul>
+        <li><a href="https://github.com/dkupratis-debug/FlaskAppEnhanced/blob/main/docs/QUALITY_SCORECARD.md" target="_blank" rel="noreferrer">Quality Scorecard</a></li>
+        <li><a href="https://github.com/dkupratis-debug/FlaskAppEnhanced/blob/main/docs/SECURITY_BEST_PRACTICES.md" target="_blank" rel="noreferrer">Security Best Practices</a></li>
+      </ul>
+    </section>
+
+    <section class="card">
+      <h2>Automation</h2>
+      <p>Use built-in workflows for engagement and sandbox drills.</p>
+      <ul>
+        <li><a href="https://github.com/dkupratis-debug/FlaskAppEnhanced/blob/main/docs/ENGAGEMENT_AUTOMATION.md" target="_blank" rel="noreferrer">Engagement Automation Guide</a></li>
+        <li><a href="https://github.com/dkupratis-debug/FlaskAppEnhanced/actions" target="_blank" rel="noreferrer">GitHub Actions</a></li>
+      </ul>
+    </section>
+  </div>
+{% endblock %}

--- a/docs/DISCUSSIONS_GUIDE.md
+++ b/docs/DISCUSSIONS_GUIDE.md
@@ -7,6 +7,8 @@ Use GitHub Discussions for learner questions, ideas, and progress updates.
 - Start Here discussion: `https://github.com/dkupratis-debug/FlaskAppEnhanced/discussions/29`
 - Beginner click guide: `docs/FIRST_10_MINUTES.md`
 - Main walkthrough: `docs/GITHUB_GUIDE.md`
+- Engagement playbook: `docs/ENGAGEMENT_PLAYBOOK.md`
+- Engagement automation: `docs/ENGAGEMENT_AUTOMATION.md`
 - Weekly prompt template: `docs/templates/WEEKLY_DISCUSSION_PROMPT.md`
 - Monthly recap template: `docs/templates/MONTHLY_RECAP_TEMPLATE.md`
 - Learner support reply template: `docs/templates/LEARNER_HELP_RESPONSE_TEMPLATE.md`

--- a/docs/ENGAGEMENT_AUTOMATION.md
+++ b/docs/ENGAGEMENT_AUTOMATION.md
@@ -1,0 +1,47 @@
+# Engagement Automation
+
+This repo includes automation to keep community activity and hands-on practice moving.
+
+## 1) Weekly Leaderboard Workflow
+
+Workflow file:
+- `.github/workflows/weekly_leaderboard.yml`
+
+What it does:
+1. Runs weekly (and manually via `workflow_dispatch`).
+1. Collects last-7-day activity for:
+   - pull requests opened
+   - pull requests merged
+   - issues opened
+   - discussions created
+1. Calculates a simple score and creates a weekly leaderboard issue.
+
+Scoring:
+- PR opened = 3
+- PR merged = 5
+- Issue opened = 1
+- Discussion started = 2
+
+## 2) Playground Branch Generator
+
+Workflow file:
+- `.github/workflows/playground_branch_generator.yml`
+
+What it does:
+1. Manually generates a branch with one intentional failure scenario.
+1. Scenarios:
+   - `markdownlint`
+   - `test`
+   - `yamllint`
+   - `links`
+1. Pushes branch to origin.
+1. Optionally opens a PR automatically.
+
+Use case:
+- Safe learner drills for "find failure -> fix -> green CI".
+
+## Safety Notes
+
+- These workflows are for training operations, not production deployment.
+- Never include secrets in generated content.
+- Keep branch protection active on `main`.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -26,6 +26,7 @@ Use this file as the top-level map for all training docs.
 
 - `docs/DISCUSSIONS_GUIDE.md`
 - `docs/ENGAGEMENT_PLAYBOOK.md`
+- `docs/ENGAGEMENT_AUTOMATION.md`
 - `docs/templates/WEEKLY_DISCUSSION_PROMPT.md`
 - `docs/templates/MONTHLY_RECAP_TEMPLATE.md`
 - `docs/templates/LEARNER_HELP_RESPONSE_TEMPLATE.md`

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -63,6 +63,15 @@ def test_learn_lab_page_loads():
     assert b"flaskappenhanced-learn-lab-progress" in res.data
 
 
+def test_launch_page_loads():
+    app = create_app()
+    client = app.test_client()
+    res = client.get("/launch")
+    assert res.status_code == 200
+    assert b"FlaskAppEnhanced Launchpad" in res.data
+    assert b"Community" in res.data
+
+
 def test_production_requires_non_default_secret_key(monkeypatch):
     monkeypatch.setenv("FLASK_ENV", "production")
     monkeypatch.delenv("SECRET_KEY", raising=False)


### PR DESCRIPTION
Adds a public launchpad page (/launch), weekly leaderboard automation, and a playground branch generator for intentional CI-failure training drills. Also updates docs index/discussions links and adds coverage tests.