### PR TITLE
Upgrade CodeQL to v4 and harden local build troubleshooting

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,12 +24,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: python
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4

--- a/README.md
+++ b/README.md
@@ -137,6 +137,14 @@ One-line local package build check:
 python -m build
 ```
 
+If Windows reports `Access is denied` under `%LOCALAPPDATA%\\Temp`, run:
+```powershell
+New-Item -ItemType Directory -Force .tmp\build-temp | Out-Null
+$env:TEMP = (Resolve-Path .tmp\build-temp).Path
+$env:TMP = $env:TEMP
+python -m build --no-isolation
+```
+
 Additional checks:
 - Markdown lint config: `.markdownlint.yml`
 - YAML lint config: `.yamllint.yml`

--- a/docs/CI_TROUBLESHOOTING_FLOW.md
+++ b/docs/CI_TROUBLESHOOTING_FLOW.md
@@ -46,6 +46,14 @@ Use this when a PR check fails.
 1. Re-run checks.
 1. Commit + push.
 
+### Build step fails locally with Windows temp permission error
+
+1. Create local temp folder: `New-Item -ItemType Directory -Force .tmp\build-temp | Out-Null`
+1. Set temp vars:
+   - `$env:TEMP = (Resolve-Path .tmp\build-temp).Path`
+   - `$env:TMP = $env:TEMP`
+1. Run build: `python -m build --no-isolation`
+
 ## Step 3: Confirm merge gates
 
 Even after checks pass, merge may still be blocked by policy:

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -65,3 +65,13 @@ Open an Issue and include:
 - what step you are on
 - what command you ran
 - exact error text
+
+### `python -m build` fails with temp-folder permission errors on Windows
+Use a repo-local temp path, then build without isolation:
+
+```powershell
+New-Item -ItemType Directory -Force .tmp\build-temp | Out-Null
+$env:TEMP = (Resolve-Path .tmp\build-temp).Path
+$env:TMP = $env:TEMP
+python -m build --no-isolation
+```


### PR DESCRIPTION
## Summary
- upgrade CodeQL GitHub Action from 3 to 4
- add Windows temp-permission troubleshooting steps for local package builds
- document fallback guidance in README/FAQ/CI troubleshooting docs

## Local validation
- ruff check .
- pytest