### PR TITLE
Add one-command local build helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,11 @@ One-line local package build check:
 python -m build
 ```
 
+One-command local build helper:
+```powershell
+.\tools\build_local.ps1
+```
+
 If Windows reports `Access is denied` under `%LOCALAPPDATA%\\Temp`, run:
 ```powershell
 New-Item -ItemType Directory -Force .tmp\build-temp | Out-Null

--- a/docs/CI_TROUBLESHOOTING_FLOW.md
+++ b/docs/CI_TROUBLESHOOTING_FLOW.md
@@ -48,6 +48,8 @@ Use this when a PR check fails.
 
 ### Build step fails locally with Windows temp permission error
 
+1. Try helper script first: `.\tools\build_local.ps1 -NoIsolation`
+1. If still failing, continue with manual temp override:
 1. Create local temp folder: `New-Item -ItemType Directory -Force .tmp\build-temp | Out-Null`
 1. Set temp vars:
    - `$env:TEMP = (Resolve-Path .tmp\build-temp).Path`

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -67,7 +67,13 @@ Open an Issue and include:
 - exact error text
 
 ### `python -m build` fails with temp-folder permission errors on Windows
-Use a repo-local temp path, then build without isolation:
+Try the helper first:
+
+```powershell
+.\tools\build_local.ps1 -NoIsolation
+```
+
+If that still fails, use a repo-local temp path, then build without isolation:
 
 ```powershell
 New-Item -ItemType Directory -Force .tmp\build-temp | Out-Null

--- a/tools/build_local.ps1
+++ b/tools/build_local.ps1
@@ -1,0 +1,48 @@
+param(
+    [string]$PythonExe = "",
+    [switch]$NoIsolation
+)
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+Set-Location $repoRoot
+
+function Resolve-Python {
+    param([string]$Requested)
+    if ($Requested -and (Test-Path $Requested)) {
+        return $Requested
+    }
+
+    $candidates = @(
+        "C:\Users\kupra\AppData\Local\Programs\Python\Python312\python.exe",
+        "C:\Users\kupra\AppData\Local\Programs\Python\Python313\python.exe"
+    )
+    foreach ($py in $candidates) {
+        if (Test-Path $py) { return $py }
+    }
+    return "python"
+}
+
+$py = Resolve-Python -Requested $PythonExe
+Write-Host "Using Python: $py"
+
+$args = @("-m", "build")
+if ($NoIsolation) { $args += "--no-isolation" }
+
+try {
+    & $py @args
+    Write-Host "Build succeeded."
+    exit 0
+}
+catch {
+    Write-Warning "Build failed: $($_.Exception.Message)"
+    Write-Host ""
+    Write-Host "Possible local policy issue (temp/write restriction)."
+    Write-Host "Try these steps:"
+    Write-Host "1) Run PowerShell as Administrator."
+    Write-Host "2) Allow python.exe in Windows Controlled Folder Access."
+    Write-Host "3) Re-run with -NoIsolation:"
+    Write-Host "   .\tools\build_local.ps1 -NoIsolation"
+    exit 1
+}


### PR DESCRIPTION
## Summary
- add 	ools/build_local.ps1 for one-command local package build checks
- auto-select known Python paths and support -NoIsolation
- improve README/FAQ/CI troubleshooting docs with helper usage

## Validation
- ruff check .
- pytest