### PR TITLE
Documentation overhaul: start path, index, and standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This repository is also set up as a GitHub learning example: you can use it to u
 
 Quick links:
 - App docs and setup: `README.md`
+- Start here (single doc entry): `docs/START_HERE.md`
 - Public launchpad page: `/launch`
 - Docs index: `docs/INDEX.md`
 - Role-based onboarding: `docs/START_HERE_BY_ROLE.md`
@@ -40,6 +41,7 @@ Quick links:
 - [Production Run (Example)](#production-run-example)
 - [Deploy a Live Demo](#deploy-a-live-demo)
 - [Troubleshooting](#troubleshooting)
+- [Documentation Navigation](#documentation-navigation)
 - [Learning Path](#learning-path)
 - [Learning Tracks](#learning-tracks)
 - [Start Here by Role](#start-here-by-role)
@@ -59,6 +61,7 @@ Quick links:
 - [Analytics and Privacy](#analytics-and-privacy)
 - [Local Engagement Dashboard (Maintainer)](#local-engagement-dashboard-maintainer)
 - [Learn GitHub Using This Repo](#learn-github-using-this-repo)
+- [Documentation Standards](#documentation-standards)
 - [GitHub Page Anatomy (Quick Reference)](#github-page-anatomy-quick-reference)
 - [Security Notes](#security-notes)
 
@@ -209,6 +212,16 @@ This repo disables pytest's cache provider in `pyproject.toml` to avoid noisy pe
 ### Releases vs Packages on GitHub
 - `Releases` in this repo contains versioned source/wheel artifacts (for example `v0.2.0`)
 - `Packages` is for registry-published packages (this repo publishes a container image to GHCR via Actions)
+
+## Documentation Navigation
+Use this order if you want the clearest learning sequence:
+
+1. `docs/START_HERE.md`
+2. `docs/FIRST_10_MINUTES.md`
+3. `docs/GITHUB_GUIDE.md`
+4. `docs/PRACTICE_EXAMPLES.md`
+5. `docs/CI_TROUBLESHOOTING_FLOW.md`
+6. `docs/TRAINING_OPERATIONS.md` (maintainers)
 
 ## Learning Path
 Use this repo as a hands-on GitHub + Flask lab.
@@ -408,6 +421,11 @@ Start here:
 - `.github/PULL_REQUEST_TEMPLATE.md` (PR structure)
 - `.github/ISSUE_TEMPLATE/` (issue forms)
 - `SECURITY.md` (security policy)
+
+## Documentation Standards
+For contributors updating docs:
+
+- `docs/DOCUMENTATION_STANDARDS.md`
 
 ## GitHub Setup Status (Example Repo)
 This repository is configured as a practical GitHub example and includes:

--- a/docs/DOCUMENTATION_STANDARDS.md
+++ b/docs/DOCUMENTATION_STANDARDS.md
@@ -1,0 +1,56 @@
+# Documentation Standards
+
+Use these rules when adding or editing docs in this repository.
+
+## Goals
+
+- Keep beginner-first clarity
+- Make every document actionable
+- Keep structure consistent across files
+- Avoid stale or conflicting instructions
+
+## Required Structure (for major docs)
+
+1. Purpose: what this doc is for
+2. Audience: who should read it
+3. Prerequisites: what user needs first
+4. Steps: explicit steps in order
+5. Expected outcome: what success looks like
+6. Troubleshooting or next step links
+
+## Writing Rules
+
+- Use plain language and short sentences.
+- Prefer exact file paths and commands.
+- Use absolute GitHub links when a click target matters.
+- Avoid ambiguous terms like "just", "simply", "obvious".
+- Keep examples copy/paste safe.
+
+## Formatting Rules
+
+- Use `1.` numbering for ordered steps.
+- Use fenced code blocks for commands.
+- Keep headings descriptive and short.
+- Keep line length readable (roughly <= 100 chars where practical).
+
+## Link Hygiene
+
+- Link to local files using repository paths (for maintainability).
+- Link to exact GitHub pages for UI click walkthroughs.
+- Re-check links when renaming docs.
+
+## Change Hygiene
+
+When a feature/workflow changes:
+
+1. Update the relevant doc page.
+2. Update `docs/INDEX.md` if discoverability changed.
+3. Update `README.md` quick links if entry points changed.
+4. Add changelog note if user-facing behavior changed.
+
+## Monthly Doc Audit
+
+1. Validate top onboarding path still works.
+2. Validate all workflows/doc references still exist.
+3. Check for outdated screenshots and stale dates.
+4. Confirm security and contribution policies still match settings.

--- a/docs/FIRST_10_MINUTES.md
+++ b/docs/FIRST_10_MINUTES.md
@@ -10,6 +10,9 @@ In 10 minutes, you will:
 - see where practice tasks live
 - see where updates/checks happen
 
+Related entry page:
+- `docs/START_HERE.md`
+
 ## What You Need
 
 - A web browser

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -2,11 +2,28 @@
 
 Use this file as the top-level map for all training docs.
 
+## Start Here
+
+- `docs/START_HERE.md` (single entry point)
+- `docs/FIRST_10_MINUTES.md` (fast click-by-click onboarding)
+- `docs/START_HERE_BY_ROLE.md` (role-based path)
+
 ## Start by Audience
 
 - Beginner: `docs/START_HERE_BY_ROLE.md`
 - Reviewer: `docs/START_HERE_BY_ROLE.md`
 - Maintainer: `docs/START_HERE_BY_ROLE.md`
+
+## Start by Goal
+
+- Learn GitHub basics quickly: `docs/FIRST_10_MINUTES.md`
+- Practice with guided tasks: `docs/PRACTICE_EXAMPLES.md`
+- Find one beginner task now: `docs/GOOD_FIRST_ISSUES.md`
+- Review a PR safely: `docs/PR_REVIEW_CHECKLIST.md`
+- Fix failing CI checks: `docs/CI_TROUBLESHOOTING_FLOW.md`
+- Run the training program: `docs/TRAINING_OPERATIONS.md`
+- Share safely in public: `docs/SAFE_SHARING.md`
+- Track engagement locally: `docs/DASHBOARD_TUTORIAL.md`
 
 ## Fast Start Guides
 
@@ -46,3 +63,7 @@ Use this file as the top-level map for all training docs.
 - `docs/images/README.md`
 - `docs/images/REPO_FLOW_MAP.md`
 - `docs/images/CAPTURE_CHECKLIST.md`
+
+## Documentation Quality
+
+- `docs/DOCUMENTATION_STANDARDS.md`

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -1,0 +1,47 @@
+# Start Here
+
+Use this page as the single entry point for all documentation.
+
+## If You Have 5 Minutes
+
+1. Read `README.md` (top section + quick links).
+2. Open `docs/FIRST_10_MINUTES.md`.
+3. Open the Start Here discussion:
+   - `https://github.com/dkupratis-debug/FlaskAppEnhanced/discussions/29`
+
+## If You Are a Beginner (First Session)
+
+1. Follow `docs/FIRST_10_MINUTES.md` exactly.
+2. Run the app locally:
+   - `python -m venv venv`
+   - `.\venv\Scripts\activate`
+   - `pip install -r requirements.txt`
+   - `python app.py`
+3. Visit:
+   - `http://127.0.0.1:5000/`
+   - `http://127.0.0.1:5000/learn`
+4. Complete one task in `docs/PRACTICE_EXAMPLES.md`.
+
+## If You Want Click-by-Click GitHub Guidance
+
+- `docs/GITHUB_GUIDE.md`
+- `docs/PR_REVIEW_CHECKLIST.md`
+- `docs/CI_TROUBLESHOOTING_FLOW.md`
+
+## If You Are Running This as a Program
+
+- `docs/TRAINING_OPERATIONS.md`
+- `docs/LEARNER_PROGRESS_TEMPLATE.md`
+- `docs/ENGAGEMENT_PLAYBOOK.md`
+- `docs/ENGAGEMENT_AUTOMATION.md`
+
+## If You Need Security and Safe Sharing
+
+- `SECURITY.md`
+- `docs/SECURITY_BEST_PRACTICES.md`
+- `docs/SAFE_SHARING.md`
+- `docs/DASHBOARD_SECURITY_GUIDE.md`
+
+## If You Need One Practice Task Right Now
+
+- `docs/GOOD_FIRST_ISSUES.md`

--- a/docs/START_HERE_BY_ROLE.md
+++ b/docs/START_HERE_BY_ROLE.md
@@ -2,6 +2,9 @@
 
 Use this page to jump directly to the right learning path.
 
+If you want one universal entry point first, read:
+- `docs/START_HERE.md`
+
 ## Beginner Path (first 60 minutes)
 
 1. Open `README.md`.
@@ -52,3 +55,9 @@ Expected outcome:
 
 Expected outcome:
 - You can run the repo as a safe, consistent training program.
+
+## Cross-Role References
+
+- Universal start path: `docs/START_HERE.md`
+- Troubleshooting path: `docs/CI_TROUBLESHOOTING_FLOW.md`
+- Security baseline: `docs/SECURITY_BEST_PRACTICES.md`


### PR DESCRIPTION
## Summary
- add docs/START_HERE.md as single entry point
- add docs/DOCUMENTATION_STANDARDS.md for consistent doc quality
- improve README navigation with structured documentation flow
- improve docs index with start-by-goal and quality sections
- tighten role/start docs references for easier onboarding

## Validation
- ruff check .
- pytest
- markdown fence balance check