### PR TITLE
Align protection docs and make build helper portable

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ For maintainers running this repo as a training program, use:
 Current hardening posture includes:
 
 - Protected `main` branch with required checks
-- Required review/approval flow before merge
+- Required review/approval flow before merge (1 approval, CODEOWNERS review, last-push approval)
 - Dependabot alerts and security updates
 - Secret scanning + push protection
 - Code scanning via CodeQL

--- a/docs/QUALITY_SCORECARD.md
+++ b/docs/QUALITY_SCORECARD.md
@@ -2,7 +2,7 @@
 
 This page explains current quality posture in plain English.
 
-Last updated: 2026-02-27
+Last updated: 2026-03-01
 
 ## Governance
 

--- a/tools/build_local.ps1
+++ b/tools/build_local.ps1
@@ -14,12 +14,18 @@ function Resolve-Python {
         return $Requested
     }
 
+    $localAppData = [Environment]::GetFolderPath("LocalApplicationData")
     $candidates = @(
-        "C:\Users\kupra\AppData\Local\Programs\Python\Python312\python.exe",
-        "C:\Users\kupra\AppData\Local\Programs\Python\Python313\python.exe"
+        (Join-Path $localAppData "Programs\Python\Python312\python.exe"),
+        (Join-Path $localAppData "Programs\Python\Python313\python.exe")
     )
     foreach ($py in $candidates) {
         if (Test-Path $py) { return $py }
+    }
+
+    # Fallback to python launcher if available.
+    if (Get-Command py -ErrorAction SilentlyContinue) {
+        return "py -3"
     }
     return "python"
 }
@@ -31,7 +37,11 @@ $args = @("-m", "build")
 if ($NoIsolation) { $args += "--no-isolation" }
 
 try {
-    & $py @args
+    if ($py -eq "py -3") {
+        & py -3 @args
+    } else {
+        & $py @args
+    }
     Write-Host "Build succeeded."
     exit 0
 }


### PR DESCRIPTION
## Summary
- align docs with live branch protection settings
- update quality scorecard timestamp and governance wording
- make 	ools/build_local.ps1 portable across Windows usernames

## Validation
- ruff check .
- pytest