### PR TITLE
Fix release tag/version alignment for v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-- No changes yet.
+- Fixed package version alignment to `0.3.1` so release tag validation matches workflow expectations.
 
 ## [0.3.1] - 2026-03-04
 

--- a/app/templates/learn_lab.html
+++ b/app/templates/learn_lab.html
@@ -109,18 +109,18 @@
         steps: [
           {
             title: "Create version tag",
-            command: "git tag v0.3.0",
+            command: "git tag v0.3.1",
             output: "Tag created locally."
           },
           {
             title: "Push tag",
-            command: "git push origin v0.3.0",
+            command: "git push origin v0.3.1",
             output: "Release workflow triggered."
           },
           {
             title: "Verify release",
             command: "gh release list --limit 5",
-            output: "v0.3.0  Latest"
+            output: "v0.3.1  Latest"
           }
         ]
       }

--- a/docs/VERSIONING_AND_RELEASES.md
+++ b/docs/VERSIONING_AND_RELEASES.md
@@ -5,7 +5,7 @@ This repo uses semantic versioning:
 
 ## How Versions Are Used Here
 - Git tags: `v0.2.3`
-- Python package version: `pyproject.toml` -> `project.version = "0.2.3"`
+- Python package version: `pyproject.toml` -> `project.version = "0.3.1"`
 - GitHub Release title/tag: created from the pushed tag
 
 ## Important Guard (Implemented)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "FlaskAppEnhanced"
-version = "0.3.0"
+version = "0.3.1"
 description = "Small Flask scaffold with security features and GitHub learning docs"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Align project version and docs/examples with released tag v0.3.1 so release validation passes for future tags.