### PR TITLE
Prepare v0.3.2 release metadata

### DIFF
--- a/.github/workflows/dependency_review.yml
+++ b/.github/workflows/dependency_review.yml
@@ -1,0 +1,22 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Dependency review
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: moderate

--- a/.github/workflows/workflow_security.yml
+++ b/.github/workflows/workflow_security.yml
@@ -1,0 +1,27 @@
+name: Workflow Security
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  workflow-security-audit:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Harden runner (audit mode)
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Lint GitHub workflows
+        uses: rhysd/actionlint@v1

--- a/.github/workflows/workflow_security.yml
+++ b/.github/workflows/workflow_security.yml
@@ -25,4 +25,3 @@ jobs:
 
       - name: Lint GitHub workflows
         uses: reviewdog/action-actionlint@v1
-

--- a/.github/workflows/workflow_security.yml
+++ b/.github/workflows/workflow_security.yml
@@ -24,4 +24,5 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Lint GitHub workflows
-        uses: rhysd/actionlint@v1
+        uses: reviewdog/action-actionlint@v1
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,4 +112,3 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Request-ID logging filter crash outside request context during app startup
 - Rate limit default parsing for `Flask-Limiter`
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-- Fixed package version alignment to `0.3.1` so release tag validation matches workflow expectations.
+- No unreleased changes.
 
-## [0.3.1] - 2026-03-04
+## [0.3.2] - 2026-03-07
+
+### Fixed
+- Corrected Snake keyboard handling to prevent page scrolling on arrow-key input.
+- Ensured full-board Snake win states use no-food terminal state semantics.
+- Added starting-board validation to prevent out-of-bounds Snake initialization on undersized boards.
+- Fixed wiki page markdown EOF formatting to satisfy pre-commit and markdownlint checks.
+
+### Changed
+- Updated wiki home links to stable relative paths to avoid flaky link-check failures.`r`n`r`n## [0.3.1] - 2026-03-04
 
 ### Added
 - Docs quality workflow (`.github/workflows/docs_quality.yml`) to validate documentation structure in CI.
@@ -103,3 +112,4 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Request-ID logging filter crash outside request context during app startup
 - Rate limit default parsing for `Flask-Limiter`
+

--- a/docs/WIKI_HOME_PAGE.md
+++ b/docs/WIKI_HOME_PAGE.md
@@ -5,9 +5,9 @@ Welcome to the project wiki.
 ## Start Here
 
 - Main repository: <https://github.com/dkupratis-debug/FlaskAppEnhanced>
-- Beginner guide: [docs/START_HERE.md](https://github.com/dkupratis-debug/FlaskAppEnhanced/blob/main/docs/START_HERE.md)
-- First 10 minutes: [docs/FIRST_10_MINUTES.md](https://github.com/dkupratis-debug/FlaskAppEnhanced/blob/main/docs/FIRST_10_MINUTES.md)
-- Practice examples: [docs/PRACTICE_EXAMPLES.md](https://github.com/dkupratis-debug/FlaskAppEnhanced/blob/main/docs/PRACTICE_EXAMPLES.md)
+- Beginner guide: [docs/START_HERE.md](START_HERE.md)
+- First 10 minutes: [docs/FIRST_10_MINUTES.md](FIRST_10_MINUTES.md)
+- Practice examples: [docs/PRACTICE_EXAMPLES.md](PRACTICE_EXAMPLES.md)
 
 ## Wiki Pages
 
@@ -24,8 +24,8 @@ Welcome to the project wiki.
 
 ## Security and Contribution
 
-- Security policy: [SECURITY.md](https://github.com/dkupratis-debug/FlaskAppEnhanced/blob/main/SECURITY.md)
-- Contributing guide: [CONTRIBUTING.md](https://github.com/dkupratis-debug/FlaskAppEnhanced/blob/main/CONTRIBUTING.md)
+- Security policy: [SECURITY.md](../SECURITY.md)
+- Contributing guide: [CONTRIBUTING.md](../CONTRIBUTING.md)
 
 ## Where to Ask Questions
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "FlaskAppEnhanced"
-version = "0.3.1"
+version = "0.3.2"
 description = "Small Flask scaffold with security features and GitHub learning docs"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- bump package version to 0.3.2
- add changelog entry for 0.3.2

## Why
- align release metadata with published v0.3.2 tag and successful release workflow

## Validation
- py -m pytest -q
- py -m ruff check .